### PR TITLE
Update fontgen.json

### DIFF
--- a/assets/fontgen.json
+++ b/assets/fontgen.json
@@ -1,6 +1,7 @@
 {
   "author": "Defold",
   "description": "This extension allows for extending an existing Defold font with more glyphs at runtime.",
+  "description_long": "This extension allows for extending an existing Defold font with more glyphs at runtime. It allows for smaller package sizes, as well as less runtime memory footprint.",
   "id": "fontgen",
   "images": {
     "hero": "",
@@ -10,7 +11,7 @@
   "license": "MIT License",
   "name": "FontGen",
   "platforms": [
-    "All",
+    "All"
   ],
   "project_url": "https://github.com/defold/extension-fontgen",
   "tags": [


### PR DESCRIPTION
Removed the extra comma in “platforms”. This could probably cause an error when updating the Asset Portal.